### PR TITLE
Raise API to 3.0.0-ALPHA11

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -4,7 +4,7 @@
 name: PurePerms
 main: _64FF00\PurePerms\PurePerms
 version: 1.4.1-3
-api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9, 3.0.0-ALPHA10]
+api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9, 3.0.0-ALPHA10, 3.0.0-ALPHA11]
 load: POSTWORLD
 author: "64FF00 & ProjectInfinity"
 website: https://github.com/PurePlugins/PurePerms

--- a/src/_64FF00/PurePerms/cmd/ListGPerms.php
+++ b/src/_64FF00/PurePerms/cmd/ListGPerms.php
@@ -3,7 +3,6 @@
 namespace _64FF00\PurePerms\cmd;
 
 use _64FF00\PurePerms\PurePerms;
-use _64FF00\PurePerms\PPGroup;
 use pocketmine\plugin\Plugin;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;

--- a/src/_64FF00/PurePerms/cmd/PPInfo.php
+++ b/src/_64FF00/PurePerms/cmd/PPInfo.php
@@ -9,7 +9,6 @@ use pocketmine\command\CommandSender;
 use pocketmine\command\ConsoleCommandSender;
 use pocketmine\command\PluginIdentifiableCommand;
 use pocketmine\plugin\Plugin;
-use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 
 class PPInfo extends Command implements PluginIdentifiableCommand

--- a/src/_64FF00/PurePerms/data/UserDataManager.php
+++ b/src/_64FF00/PurePerms/data/UserDataManager.php
@@ -91,6 +91,7 @@ class UserDataManager
     }
 
     /**
+     * @param $player IPlayer
      * @param null $levelName
      * @return array
      */

--- a/src/_64FF00/PurePerms/event/PPGroupChangedEvent.php
+++ b/src/_64FF00/PurePerms/event/PPGroupChangedEvent.php
@@ -25,6 +25,17 @@ class PPGroupChangedEvent extends PluginEvent
     */
 
     public static $handlerList = null;
+    /**
+     * @var PPGroup
+     */
+    private $group;
+
+    /**
+     * @var IPlayer
+     */
+    private $player;
+
+    private $levelName;
 
     /**
      * @param PurePerms $plugin

--- a/src/_64FF00/PurePerms/event/PPRankExpiredEvent.php
+++ b/src/_64FF00/PurePerms/event/PPRankExpiredEvent.php
@@ -2,7 +2,6 @@
 
 namespace _64FF00\PurePerms\event;
 
-use _64FF00\PurePerms\PPGroup;
 use _64FF00\PurePerms\PurePerms;
 
 use pocketmine\event\plugin\PluginEvent;
@@ -36,7 +35,6 @@ class PPRankExpiredEvent extends PluginEvent
     /**
      * @param PurePerms $plugin
      * @param IPlayer $player
-     * @param PPGroup $group
      * @param $levelName
      */
     public function __construct(PurePerms $plugin, IPlayer $player, $levelName)

--- a/src/_64FF00/PurePerms/event/PPRankExpiredEvent.php
+++ b/src/_64FF00/PurePerms/event/PPRankExpiredEvent.php
@@ -27,6 +27,13 @@ class PPRankExpiredEvent extends PluginEvent
     public static $handlerList = null;
 
     /**
+     * @var IPlayer
+     */
+    private $player;
+
+    private $levelName;
+
+    /**
      * @param PurePerms $plugin
      * @param IPlayer $player
      * @param PPGroup $group


### PR DESCRIPTION
No significant changes to code were necessary.  Updates to `PPGroupChangedEvent` and `PPRankExpiredEvent`  include the addition of class properties to fix dynamic declaration of variables.

Tested with a Windows 10 machine using PocketMine-MP commit https://github.com/pmmp/PocketMine-MP/commit/5858025d90a03a0aee6bc46123d71008e59e6503.

Two clients were tested.  One on Windows 10 and the other on Android.  No apparent complications were discovered and permissions worked as expected.