### PR TITLE
PurePerms does NOT accept permissions per world

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -28,10 +28,6 @@ default-language: en
 # - true / false
 disable-op: true
 
-# Setting this option will allow you to use per-world permissions
-# - true / false
-enable-multiworld-perms: false
-
 # Enables 'Noeul', a 'pointless' security management system for PurePerms
 # - true / false
 enable-noeul-sixtyfour: false


### PR DESCRIPTION
For many who have spent their time activating this option to later see that it is useless at all, eliminating this option will save many headaches for those people who really needed permissions per world.